### PR TITLE
Catch parse errors and hand them to error_handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:
 all: build
 
 test:
-	dune runtest
+	dune runtest --no-buffer
 
 examples:
 	dune build @examples

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -264,6 +264,11 @@ module Reader = struct
   let is_closed t =
     t.closed
 
+  let is_failed t =
+    match t.parse_state with
+    | Fail _ -> true
+    | _ -> false
+
   let transition t state =
     match state with
     | AU.Done(consumed, Ok ())
@@ -309,11 +314,6 @@ module Reader = struct
   let force_close t =
     ignore (read_with_more t Bigstringaf.empty ~off:0 ~len:0 Complete : int);
   ;;
-
-  let is_parse_failure t =
-    match t.parse_state with
-    | Fail _ -> true
-    | _ -> false
 
   let next t =
     match t.parse_state with

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -310,12 +310,17 @@ module Reader = struct
     ignore (read_with_more t Bigstringaf.empty ~off:0 ~len:0 Complete : int);
   ;;
 
+  let is_parse_failure t =
+    match t.parse_state with
+    | Fail _ -> true
+    | _ -> false
+
   let next t =
     match t.parse_state with
     | Done ->
       if t.closed
       then `Close
       else `Read
-    | Fail    _ -> `Close
+    | Fail failure -> `Error failure
     | Partial _ -> `Read
 end

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -66,6 +66,10 @@ type t =
        has already had [request_handler] called on it. *)
   ; wakeup_writer  : (unit -> unit) list ref
   ; wakeup_reader  : (unit -> unit) list ref
+    (* Represents an unrecoverable error that will cause the connection to
+     * shutdown. Holds on to the response body created by the error handler
+     * that might be streaming to the client. *)
+  ; mutable error_code : [`Ok | `Error of [`write] Body.t ]
   }
 
 let is_closed t =
@@ -143,6 +147,7 @@ let create ?(config=Config.default) ?(error_handler=default_error_handler) reque
   ; request_queue
   ; wakeup_writer
   ; wakeup_reader   = ref []
+  ; error_code = `Ok
   }
 
 let shutdown_reader t =
@@ -181,10 +186,20 @@ let set_error_and_handle ?request t error =
     in
     shutdown_reader t;
     let writer = t.writer in
-    t.error_handler ?request error (fun headers ->
-      Writer.write_response writer (Response.create ~headers status);
-      Body.of_faraday (Writer.faraday writer));
-    wakeup_writer t;
+    match t.error_code with
+    | `Ok ->
+      let body = Body.of_faraday (Writer.faraday writer) in
+      t.error_code <- `Error body;
+      t.error_handler ?request error (fun headers ->
+          Writer.write_response writer (Response.create ~headers status);
+          wakeup_writer t;
+          body)
+    | `Error _ ->
+      (* This should not happen. Even if we try to read more, the parser does
+       * not ingest it, and even if someone attempts to feed more bytes to the
+       * server when we already told them to [`Close], it's not really our
+       * problem. *)
+      assert false
   end
 
 let report_exn t exn =
@@ -211,7 +226,12 @@ let advance_request_queue_if_necessary t =
       else if not (Reqd.requires_input reqd)
       then shutdown_reader t
     end
-  end else if Reader.is_closed t.reader && (not (Reader.is_parse_failure t.reader))
+  end else if Reader.is_failed t.reader then
+    (* Don't tear down the whole connection if we saw an unrecoverable parsing
+     * error, as we might be in the process of streaming back the error
+     * response body to the client. *)
+    shutdown_reader t
+  else if Reader.is_closed t.reader
   then shutdown t
 
 let _next_read_operation t =
@@ -272,6 +292,7 @@ let yield_writer t k =
     else if Reqd.persistent_connection reqd
     then on_wakeup_writer t k
     else begin shutdown t; k () end
-  end else if Writer.is_closed t.writer then k () else begin
-    on_wakeup_writer t k
-  end
+  end else if Writer.is_closed t.writer then k () else
+  match t.error_code with
+    | `Ok -> on_wakeup_writer t k
+    | `Error body -> Body.when_ready_to_write body k

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -184,7 +184,7 @@ let set_error_and_handle ?request t error =
     t.error_handler ?request error (fun headers ->
       Writer.write_response writer (Response.create ~headers status);
       Body.of_faraday (Writer.faraday writer));
-    shutdown_writer t;
+    wakeup_writer t;
   end
 
 let report_exn t exn =

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -184,6 +184,7 @@ let set_error_and_handle ?request t error =
     t.error_handler ?request error (fun headers ->
       Writer.write_response writer (Response.create ~headers status);
       Body.of_faraday (Writer.faraday writer));
+    shutdown_writer t;
   end
 
 let report_exn t exn =
@@ -210,7 +211,7 @@ let advance_request_queue_if_necessary t =
       else if not (Reqd.requires_input reqd)
       then shutdown_reader t
     end
-  end else if Reader.is_closed t.reader
+  end else if Reader.is_closed t.reader && (not (Reader.is_parse_failure t.reader))
   then shutdown t
 
 let _next_read_operation t =

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -537,30 +537,72 @@ module Server_connection = struct
       `Read (next_read_operation t);
   ;;
 
+  let malformed_request_string =
+    "GET / HTTP/1.1\r\nconnection: close\r\nX-Other-Header : shouldnt_have_space_before_colon\r\n\r\n"
+
+  let eof_request_string =
+    "GET / HTTP/1.1\r\nconnection: close\r\nX-Other-Header: EOF_after_this"
+
   let basic_handler body reqd =
     let request_body = Reqd.request_body reqd in
     Body.close_reader request_body;
     Reqd.respond_with_string reqd (Response.create `OK) body;
   ;;
 
-  let test_malformed_request () =
-    let malformed_request_string =
-      "GET / HTTP/1.1\r\nconnection: close\r\nX-Other-Header : shouldnt_have_space_before_colon\r\n\r\n"
-    in
+  let test_malformed conn =
     let writer_woken_up = ref false in
-    let t = create ~error_handler (basic_handler "") in
     Alcotest.check write_operation "Writer is in a yield state"
-      `Yield (next_write_operation t);
-    yield_writer t (fun () -> writer_woken_up := true);
+      `Yield (next_write_operation conn);
+    yield_writer conn (fun () -> writer_woken_up := true);
     let len = String.length malformed_request_string in
     let input = Bigstringaf.of_string malformed_request_string ~off:0 ~len in
-    let c = read t input ~off:0 ~len in
+    let c = read conn input ~off:0 ~len in
     Alcotest.(check bool) "read doesn't consume all input"
       true (c < String.length malformed_request_string);
     Alcotest.check read_operation "Error shuts down the reader"
-      `Close (next_read_operation t);
+      `Close (next_read_operation conn);
     Alcotest.(check bool) "Writer woken up"
-      true !writer_woken_up;
+      true !writer_woken_up
+
+  let test_malformed_request () =
+    let t = create ~error_handler (basic_handler "") in
+    test_malformed t;
+    Alcotest.(check (option string)) "Error response written"
+      (Some "HTTP/1.1 400 Bad Request\r\n\r\ngot an error")
+      (next_write_operation t |> Write_operation.to_write_as_string)
+  ;;
+
+  let test_malformed_request_async () =
+    let continue = ref (fun () -> ()) in
+    let error_handler ?request:_ _error start_response =
+      let resp_body = start_response Headers.empty in
+      continue := (fun () ->
+        Body.write_string resp_body "got an error";
+        Body.close_writer resp_body)
+    in
+    let t = create ~error_handler (basic_handler "") in
+    test_malformed t;
+    !continue ();
+    Alcotest.(check (option string)) "Error response written"
+      (Some "HTTP/1.1 400 Bad Request\r\n\r\ngot an error")
+      (next_write_operation t |> Write_operation.to_write_as_string)
+  ;;
+
+  let test_malformed_request_async_multiple_errors () =
+    let continue = ref (fun () -> ()) in
+    let error_handler ?request:_ _error start_response =
+      let resp_body = start_response Headers.empty in
+      continue := (fun () ->
+        Body.write_string resp_body "got an error";
+        Body.close_writer resp_body)
+    in
+    let t = create ~error_handler (basic_handler "") in
+    test_malformed t;
+    !continue ();
+    let len = String.length malformed_request_string in
+    let input = Bigstringaf.of_string malformed_request_string ~off:0 ~len in
+    let c = read t input ~off:0 ~len in
+    Alcotest.(check int) "read doesn't consume more input" 0 c;
     Alcotest.(check (option string)) "Error response written"
       (Some "HTTP/1.1 400 Bad Request\r\n\r\ngot an error")
       (next_write_operation t |> Write_operation.to_write_as_string)
@@ -573,21 +615,8 @@ module Server_connection = struct
   ;;
 
   let test_malformed_request_eof () =
-    let eof_request_string =
-      "GET / HTTP/1.1\r\nconnection: close\r\nX-Other-Header: EOF_after_this"
-    in
-    let writer_woken_up = ref false in
     let t = create ~error_handler (basic_handler "") in
-    Alcotest.check write_operation "Writer is in a yield state"
-      `Yield (next_write_operation t);
-    yield_writer t (fun () -> writer_woken_up := true);
-    let c = read_string_eof t eof_request_string in
-    Alcotest.(check int) "read consumes all input"
-      (String.length eof_request_string) c;
-    Alcotest.check read_operation "Error shuts down the reader"
-      `Close (next_read_operation t);
-    Alcotest.(check bool) "Writer woken up"
-      true !writer_woken_up;
+    test_malformed t;
     Alcotest.(check (option string)) "Error response written"
       (Some "HTTP/1.1 400 Bad Request\r\n\r\ngot an error")
       (next_write_operation t |> Write_operation.to_write_as_string)
@@ -602,16 +631,14 @@ module Server_connection = struct
   ;;
 
   let test_malformed_request_streaming_error_response () =
-    let default_waiting = Sys.opaque_identity (fun () -> ()) in
     let eof_request_string =
       "GET / HTTP/1.1\r\nconnection: close\r\nX-Other-Header: EOF_after_this"
     in
     let writer_woken_up = ref false in
-    let continue_error = ref default_waiting in
+    let continue_error = ref (fun () -> ()) in
     let error_handler ?request error start_response =
       continue_error := (fun () ->
-        streaming_error_handler continue_error ?request error start_response
-      )
+        streaming_error_handler continue_error ?request error start_response)
     in
     let t = create ~error_handler (basic_handler "") in
     Alcotest.check write_operation "Writer is in a yield state"
@@ -625,23 +652,16 @@ module Server_connection = struct
     !continue_error ();
     Alcotest.(check bool) "Writer woken up" true !writer_woken_up;
     writer_woken_up := false;
-    Alcotest.(check (option string)) "Error response and first output written"
-      (Some "HTTP/1.1 400 Bad Request\r\n\r\ngot an error\n")
-      (next_write_operation t |> Write_operation.to_write_as_string);
-    let iovecs = match next_write_operation t with
-    | `Write iovecs -> iovecs
-    | _ -> assert false
-    in
-    report_write_result t (`Ok (IOVec.lengthv iovecs));
+    write_string t ~msg:"Error response and first output written"
+      "HTTP/1.1 400 Bad Request\r\n\r\ngot an error\n";
     Alcotest.check write_operation "Writer is in a yield state"
       `Yield (next_write_operation t);
     yield_writer t (fun () -> writer_woken_up := true);
     !continue_error ();
     Alcotest.(check bool) "Writer woken up once more input is available"
       true !writer_woken_up;
-    Alcotest.(check (option string)) "Error response written"
-      (Some "more output")
-      (next_write_operation t |> Write_operation.to_write_as_string)
+    write_string t ~msg:"Rest of the error response written" "more output";
+    Alcotest.(check bool) "Connection is shutdown" true (is_closed t);
   ;;
 
   let tests =
@@ -658,6 +678,8 @@ module Server_connection = struct
     ; "asynchronous error, asynchronous handling", `Quick, test_asynchronous_error_asynchronous_handling
     ; "chunked encoding", `Quick, test_chunked_encoding
     ; "malformed request", `Quick, test_malformed_request
+    ; "malformed request (async)", `Quick, test_malformed_request_async
+    ; "multiple malformed requests?", `Quick, test_malformed_request_async_multiple_errors
     ; "malformed request (EOF)", `Quick, test_malformed_request_eof
     ; "malformed request, streaming response", `Quick, test_malformed_request_streaming_error_response
     ]
@@ -812,6 +834,6 @@ let () =
     [ "version"          , Version.tests
     ; "method"           , Method.tests
     ; "iovec"            , IOVec.tests
-    ; "clien connection" , Client_connection.tests
+    ; "client connection" , Client_connection.tests
     ; "server connection", Server_connection.tests
     ]


### PR DESCRIPTION
Also fixes streaming async error reporting in the event of parsing failures