### PR TITLE
client_connection: add upgrade support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,8 @@ Unreleased
   interface, don't require a `report_exn` function, only a `state` function
   that returns the socket state
   ([#30](https://github.com/anmonteiro/httpaf/pull/30))
+- httpaf, httpaf-lwt, httpaf-async: Add support for upgrading connections on
+  the client. ([#31](https://github.com/anmonteiro/httpaf/pull/31))
 
 httpaf (upstream) 0.6.5
 --------------

--- a/async/httpaf_async.ml
+++ b/async/httpaf_async.ml
@@ -185,6 +185,8 @@ module Client = struct
               |> ignore;
               reader_thread ()
           end
+      | `Yield ->
+        Client_connection.yield_writer conn reader_thread;
       | `Close ->
         (* Log.Global.printf "read_close(%d)%!" (Fd.to_int_exn fd); *)
         Ivar.fill read_complete ();

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1046,8 +1046,8 @@
         "@opam/core_kernel@opam:v0.13.0@3cae740d"
       ]
     },
-    "@opam/ppxlib@opam:0.10.0@43604fcc": {
-      "id": "@opam/ppxlib@opam:0.10.0@43604fcc",
+    "@opam/ppxlib@opam:0.10.0@011ee889": {
+      "id": "@opam/ppxlib@opam:0.10.0@011ee889",
       "name": "@opam/ppxlib",
       "version": "opam:0.10.0",
       "source": {
@@ -1127,14 +1127,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/variantslib@opam:v0.13.0@7fe1097f",
-        "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/variantslib@opam:v0.13.0@7fe1097f",
-        "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
     },
@@ -1157,14 +1157,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/typerep@opam:v0.13.0@44f322a7",
-        "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/typerep@opam:v0.13.0@44f322a7",
-        "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
     },
@@ -1237,13 +1237,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
     },
@@ -1265,7 +1265,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/ppx_here@opam:v0.13.0@13e16b51",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
@@ -1273,7 +1273,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/ppx_here@opam:v0.13.0@13e16b51",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
@@ -1297,7 +1297,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/ppx_here@opam:v0.13.0@13e16b51",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
@@ -1305,7 +1305,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/ppx_here@opam:v0.13.0@13e16b51",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
@@ -1330,14 +1330,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/sexplib0@opam:v0.13.0@3f54c2be",
-        "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/sexplib0@opam:v0.13.0@3f54c2be",
-        "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
     },
@@ -1359,11 +1359,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
@@ -1385,13 +1385,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
     },
@@ -1414,14 +1414,14 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/stdio@opam:v0.13.0@eb59d879",
-        "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/stdio@opam:v0.13.0@eb59d879",
-        "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
     },
@@ -1445,7 +1445,7 @@
       "dependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/time_now@opam:v0.13.0@b3c38ba1",
         "@opam/stdio@opam:v0.13.0@eb59d879",
-        "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_base@opam:v0.13.0@7b3a7de2",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
@@ -1454,7 +1454,7 @@
       "devDependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/time_now@opam:v0.13.0@b3c38ba1",
         "@opam/stdio@opam:v0.13.0@eb59d879",
-        "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_base@opam:v0.13.0@7b3a7de2",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
@@ -1477,13 +1477,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
     },
@@ -1505,14 +1505,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/octavius@opam:1.2.2@b328d1f1",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/octavius@opam:1.2.2@b328d1f1",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
@@ -1535,7 +1535,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_variants_conv@opam:v0.13.0@a13c772d",
         "@opam/ppx_typerep_conv@opam:v0.13.0@75008d24",
         "@opam/ppx_stable@opam:v0.13.0@53df8a9c",
@@ -1561,7 +1561,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_variants_conv@opam:v0.13.0@a13c772d",
         "@opam/ppx_typerep_conv@opam:v0.13.0@75008d24",
         "@opam/ppx_stable@opam:v0.13.0@53df8a9c",
@@ -1604,13 +1604,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
     },
@@ -1632,13 +1632,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
     },
@@ -1660,7 +1660,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/ppx_compare@opam:v0.13.0@c5278326",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
@@ -1668,7 +1668,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/ppx_compare@opam:v0.13.0@c5278326",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
@@ -1692,14 +1692,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/fieldslib@opam:v0.13.0@e5d61627",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/fieldslib@opam:v0.13.0@e5d61627",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
@@ -1722,14 +1722,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_here@opam:v0.13.0@13e16b51",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_here@opam:v0.13.0@13e16b51",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
@@ -1753,7 +1753,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/stdio@opam:v0.13.0@eb59d879",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_variants_conv@opam:v0.13.0@a13c772d",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/ppx_inline_test@opam:v0.13.0@d920653b",
@@ -1768,7 +1768,7 @@
       ],
       "devDependencies": [
         "ocaml@4.9.0@d41d8cd9", "@opam/stdio@opam:v0.13.0@eb59d879",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_variants_conv@opam:v0.13.0@a13c772d",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/ppx_inline_test@opam:v0.13.0@d920653b",
@@ -1798,13 +1798,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
     },
@@ -1885,14 +1885,14 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
@@ -1950,13 +1950,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
     },
@@ -1978,13 +1978,13 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/base@opam:v0.13.0@93f21415",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/base@opam:v0.13.0@93f21415"
       ]
     },
@@ -2006,7 +2006,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_here@opam:v0.13.0@13e16b51",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/bin_prot@opam:v0.13.0@1afbff52",
@@ -2014,7 +2014,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_here@opam:v0.13.0@13e16b51",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/bin_prot@opam:v0.13.0@1afbff52",
@@ -2039,12 +2039,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_inline_test@opam:v0.13.0@d920653b",
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_inline_test@opam:v0.13.0@d920653b",
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
@@ -2067,7 +2067,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/ppx_js_style@opam:v0.13.0@1abe0151",
         "@opam/ppx_hash@opam:v0.13.0@edcf7ab1",
@@ -2077,7 +2077,7 @@
         "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/ppx_js_style@opam:v0.13.0@1abe0151",
         "@opam/ppx_hash@opam:v0.13.0@edcf7ab1",
@@ -2105,7 +2105,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/ppx_here@opam:v0.13.0@13e16b51",
         "@opam/ppx_compare@opam:v0.13.0@c5278326",
@@ -2115,7 +2115,7 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "ocaml@4.9.0@d41d8cd9", "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_conv@opam:v0.13.0@53058ed2",
         "@opam/ppx_here@opam:v0.13.0@13e16b51",
         "@opam/ppx_compare@opam:v0.13.0@c5278326",
@@ -4209,7 +4209,7 @@
       "dependencies": [
         "ocaml@4.9.0@d41d8cd9",
         "@opam/splittable_random@opam:v0.13.0@cedb875a",
-        "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_message@opam:v0.13.0@08a6a545",
         "@opam/ppx_let@opam:v0.13.0@5703d2be",
         "@opam/ppx_fields_conv@opam:v0.13.0@3c767913",
@@ -4221,7 +4221,7 @@
       "devDependencies": [
         "ocaml@4.9.0@d41d8cd9",
         "@opam/splittable_random@opam:v0.13.0@cedb875a",
-        "@opam/ppxlib@opam:0.10.0@43604fcc",
+        "@opam/ppxlib@opam:0.10.0@011ee889",
         "@opam/ppx_sexp_message@opam:v0.13.0@08a6a545",
         "@opam/ppx_let@opam:v0.13.0@5703d2be",
         "@opam/ppx_fields_conv@opam:v0.13.0@3c767913",

--- a/esy.lock/opam/ppxlib.0.10.0/opam
+++ b/esy.lock/opam/ppxlib.0.10.0/opam
@@ -14,7 +14,7 @@ run-test: [
   ["dune" "runtest" "-p" name "-j" jobs] { ocaml:version >= "4.06" & ocaml:version < "4.08" }
 ]
 depends: [
-  "ocaml"                   {>= "4.04.1"}
+  "ocaml"                   {>= "4.04.1" & < "4.10.0"}
   "base"                    {>= "v0.11.0"}
   "dune"                    {>= "1.11"}
   "ocaml-compiler-libs"     {>= "v0.11.0"}

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -49,6 +49,7 @@ type t =
     (* invariant: If [request_queue] is not empty, then the head of the queue
        has already written the request headers to the wire. *)
   ; wakeup_writer  : (unit -> unit) list ref
+  ; wakeup_reader  : (unit -> unit) list ref
   }
 
 let is_closed t =
@@ -63,6 +64,11 @@ let is_active t =
 let current_respd_exn t =
   Queue.peek t.request_queue
 
+let on_wakeup_reader t k =
+  if is_closed t
+  then failwith "on_wakeup_reader on closed conn"
+  else t.wakeup_reader := k::!(t.wakeup_reader)
+
 let on_wakeup_writer t k =
   if is_closed t
   then failwith "on_wakeup_writer on closed conn"
@@ -73,6 +79,11 @@ let wakeup_writer t =
   t.wakeup_writer := [];
   List.iter (fun f -> f ()) fs
 
+let wakeup_reader t =
+  let fs = !(t.wakeup_reader) in
+  t.wakeup_reader := [];
+  List.iter (fun f -> f ()) fs
+
 let[@ocaml.warning "-16"] create ?(config=Config.default) =
   let request_queue = Queue.create () in
   { config
@@ -80,6 +91,7 @@ let[@ocaml.warning "-16"] create ?(config=Config.default) =
   ; writer = Writer.create ()
   ; request_queue
   ; wakeup_writer = ref []
+  ; wakeup_reader = ref []
   }
 
 let request t request ~error_handler ~response_handler =
@@ -123,6 +135,7 @@ let shutdown_reader t =
   Reader.force_close t.reader;
   if is_active t
   then Respd.close_response_body (current_respd_exn t)
+  else wakeup_reader t
 
 let shutdown_writer t =
   flush_request_body t;
@@ -136,6 +149,7 @@ let shutdown_writer t =
 let shutdown t =
   shutdown_reader t;
   shutdown_writer t;
+  wakeup_reader t;
   wakeup_writer t;
 ;;
 
@@ -221,7 +235,6 @@ let _next_read_operation t =
     Reader.next t.reader
 
 let next_read_operation t =
-  (* advance_request_queue_if_necessary t; *)
   match _next_read_operation t with
   | `Error (`Parse(marks, message)) ->
     let message = String.concat "" [ String.concat ">" marks; ": "; message] in
@@ -266,9 +279,8 @@ let next_write_operation t =
   Writer.next t.writer
 ;;
 
-let yield_reader _t _k =
-  ()
-  (* on_wakeup_reader t k *)
+let yield_reader t k =
+  on_wakeup_reader t k
 ;;
 
 let yield_writer t k =

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -775,7 +775,7 @@ module Client_connection : sig
     -> response_handler:response_handler
     -> [`write] Body.t
 
-  val next_read_operation : t -> [ `Read | `Close ]
+  val next_read_operation : t -> [ `Read | `Yield | `Close ]
   (** [next_read_operation t] returns a value describing the next operation
       that the caller should conduct on behalf of the connection. *)
 
@@ -812,6 +812,8 @@ module Client_connection : sig
         {next_write_operation}. }
         {- [`Closed] indicates that the output destination will no longer
         accept bytes from the write processor. }} *)
+
+  val yield_reader : t -> (unit -> unit) -> unit
 
   val yield_writer : t -> (unit -> unit) -> unit
   (** [yield_writer t continue] registers with the connection to call

--- a/lwt/httpaf_lwt.ml
+++ b/lwt/httpaf_lwt.ml
@@ -217,7 +217,7 @@ module Client (Io: IO) = struct
     let read_buffer = Buffer.create config.read_buffer_size in
     let read_loop_exited, notify_read_loop_exited = Lwt.wait () in
 
-    let read_loop () =
+    let rec read_loop () =
       let rec read_loop_step () =
         match Client_connection.next_read_operation connection with
         | `Read ->
@@ -233,6 +233,10 @@ module Client (Io: IO) = struct
             |> ignore;
             read_loop_step ()
           end
+
+        | `Yield ->
+          Client_connection.yield_reader connection read_loop;
+          Lwt.return_unit
 
         | `Close ->
           Lwt.wakeup_later notify_read_loop_exited ();


### PR DESCRIPTION
This should be fairly simple: in practice, the client just needs to be aware that it's been upgraded so that the state machine continually issues `Yield` operations.