### PR TITLE
Fix the order of parsed request / response headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,10 @@ Unreleased
   ([#30](https://github.com/anmonteiro/httpaf/pull/30))
 - httpaf, httpaf-lwt, httpaf-async: Add support for upgrading connections on
   the client. ([#31](https://github.com/anmonteiro/httpaf/pull/31))
+- httpaf: Fix the order of parsed request / response headers to match what it's
+  advertised in the interface file. They are now served to the respective
+  handlers in the original transmission order
+  ([#32](https://github.com/anmonteiro/httpaf/pull/32))
 
 httpaf (upstream) 0.6.5
 --------------

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -106,14 +106,16 @@ let header =
   <?> "header"
 
 let headers =
-  let cons x xs = x :: xs in
   fix (fun headers ->
-    let _emp = return [] in
-    let _rec = lift2 cons header headers in
+    let _emp = return (fun x -> x) in
+    let _rec =
+      lift2 (fun header f headers -> f (header :: headers)) header headers
+    in
     peek_char_fail
     >>= function
       | '\r' -> _emp
       | _    -> _rec)
+  >>| fun f -> f []
 
 let request =
   let meth = take_till P.is_space >>| Method.of_string in

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -812,7 +812,7 @@ module Server_connection = struct
         ; "Connection"     , "close"
         ; "Accept"         , "application/json, text/plain, */*"
         ; "Accept-Language", "en-US,en;q=0.5" ]
-        (Headers.to_rev_list (Reqd.request reqd).headers);
+        (Headers.to_list (Reqd.request reqd).headers);
       Body.close_reader (Reqd.request_body reqd);
       continue_response := (fun () ->
         Reqd.respond_with_string reqd (Response.create `OK) "");


### PR DESCRIPTION
Serve headers to request / response handlers in the original
transmission order.