### PR TITLE
Merge recent upstream changes

### DIFF
--- a/lib/httpaf.ml
+++ b/lib/httpaf.ml
@@ -13,5 +13,6 @@ module Server_connection = Server_connection
 module Client_connection = Client_connection
 
 module Httpaf_private = struct
+  module Parse = Parse
   module Serialize = Serialize
 end

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -841,6 +841,11 @@ end
 (**/**)
 
 module Httpaf_private : sig
+  module Parse : sig
+    val request : Request.t Angstrom.t
+    val response : Response.t Angstrom.t
+  end
+
   module Serialize : sig
     val write_request  : Faraday.t -> Request.t  -> unit
     val write_response : Faraday.t -> Response.t -> unit


### PR DESCRIPTION
also fixes Parse.next which remains broken upstream to work with parse failures.