### PR TITLE
Fix premature SSL termination in the SSL / TLS runtimes

### DIFF
--- a/async/httpaf_async.ml
+++ b/async/httpaf_async.ml
@@ -333,6 +333,7 @@ module Make_client (Io : IO) = struct
       | `Close _ ->
         (* Log.Global.printf "write_close(%d)%!" (Fd.to_int_exn fd); *)
         Ivar.fill write_complete ();
+        Io.shutdown_send socket;
     in
     let conn_monitor = Monitor.create () in
     Scheduler.within ~monitor:conn_monitor reader_thread;

--- a/httpaf-lwt-unix.opam
+++ b/httpaf-lwt-unix.opam
@@ -21,7 +21,7 @@ depends: [
   "lwt"
 ]
 depopts: [
-  "tls" {>= "0.11.0"}
+  "tls"
   "lwt_ssl"
 ]
 pin-depends: [

--- a/lwt-unix/ssl_io_real.ml
+++ b/lwt-unix/ssl_io_real.ml
@@ -40,23 +40,35 @@ struct
   type socket = Lwt_ssl.socket
   type addr = Unix.sockaddr
 
+  let close ssl =
+    Lwt_ssl.ssl_shutdown ssl >>= fun () ->
+      Lwt.catch
+      (fun () -> Lwt.wrap2 Lwt_ssl.shutdown ssl Unix.SHUTDOWN_ALL)
+      (function
+       | Unix.Unix_error (Unix.ENOTCONN, _, _) ->
+           Lwt.return_unit
+       | exn -> Lwt.fail exn)
+      >>= fun () ->
+       let fd = Lwt_ssl.get_fd ssl in
+       match Lwt_unix.state fd with
+       | Lwt_unix.Closed -> Lwt.return_unit
+       | _ ->
+         Lwt.catch
+           (fun () -> Lwt_ssl.close ssl)
+           (fun _exn -> Lwt.return_unit)
+
   let read ssl bigstring ~off ~len =
     Lwt.catch
       (fun () ->
-        Lwt_ssl.read_bytes ssl bigstring off len)
+        Lwt_ssl.read_bytes ssl bigstring off len >|= function
+          | 0 -> `Eof
+          | n -> `Ok n)
       (function
         | Unix.Unix_error (Unix.EBADF, _, _) as exn ->
           Lwt.fail exn
         | exn ->
-          Lwt.async (fun () ->
-              Lwt_ssl.ssl_shutdown ssl >>= fun () ->
-              Lwt_ssl.close ssl);
+          Lwt.async (fun () -> close ssl);
           Lwt.fail exn)
-    >>= fun bytes_read ->
-    if bytes_read = 0 then
-      Lwt.return `Eof
-    else
-      Lwt.return (`Ok bytes_read)
 
   let writev ssl iovecs =
     Lwt.catch
@@ -85,11 +97,6 @@ struct
   let shutdown_send _ssl = ()
 
   let shutdown_receive _ssl = ()
-
-  let close ssl =
-    Lwt_ssl.ssl_shutdown ssl >>= fun () ->
-      Lwt.wrap2 Lwt_ssl.shutdown ssl Unix.SHUTDOWN_ALL >>= fun () ->
-      Lwt_ssl.close ssl
 
   let state ssl =
     match Lwt_unix.state (Lwt_ssl.get_fd ssl) with

--- a/lwt-unix/tls_io_real.ml
+++ b/lwt-unix/tls_io_real.ml
@@ -74,9 +74,9 @@ module Io :
         | exn ->
           Lwt.fail exn)
 
-  let shutdown_send tls = ignore (Tls_lwt.Unix.close_tls tls)
+  let shutdown_send _tls = ()
 
-  let shutdown_receive tls = ignore (Tls_lwt.Unix.close_tls tls)
+  let shutdown_receive _tls = ()
 
   let close tls = Tls_lwt.Unix.close tls
 

--- a/lwt/httpaf_lwt.ml
+++ b/lwt/httpaf_lwt.ml
@@ -273,6 +273,7 @@ module Client (Io: IO) = struct
 
         | `Close _ ->
           Lwt.wakeup_later notify_write_loop_exited ();
+          Io.shutdown_send socket;
           Lwt.return_unit
       in
 


### PR DESCRIPTION
The SSL / TLS runtime implementations for `shutdown_send` and
`shutdown_receive` were in fact tearing down the full-duplex connection
instead of shutting down only one part of it. In fact, we can't shut
down a single part of the connection in these runtimes, as the TLS
shutdown requires both endpoints to be involved in order to prevent
truncation attacks.

A previous symptom of this problem was fixed in
https://github.com/inhabitedtype/httpaf/pull/84, though it's clear now
that it was the wrong fix.

fixes #46 