### PR TITLE
Fix OpenSSL runtime shutdown

### DIFF
--- a/lwt-unix/tls_io_real.ml
+++ b/lwt-unix/tls_io_real.ml
@@ -80,8 +80,6 @@ module Io :
 
   let shutdown_receive _tls = ()
 
-  let close tls = Tls_lwt.Unix.close tls
-
   let state tls =
     match Tls_lwt.Unix.epoch tls with `Error -> `Error | `Ok _ -> `Open
 end


### PR DESCRIPTION
In some cases (especially when receiving a response with a close
delimited body), the peer closes the connection before we attempt to SSL
shutdown, leading to unnecessary reporting of errors such as
`Unix.Unix_error(Unix.EBADF)`