### PR TITLE
parser: commit after parsing each header line

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -103,13 +103,14 @@ let header =
   lift2 (fun key value -> (key, value))
     (take_till P.is_space_or_colon <* char ':' <* spaces)
     (take_till P.is_cr <* eol >>| String.trim)
+  <* commit
   <?> "header"
 
 let headers =
   fix (fun headers ->
     let _emp = return (fun x -> x) in
     let _rec =
-      lift2 (fun header f headers -> f (header :: headers)) (header <* commit) headers
+      lift2 (fun header f headers -> f (header :: headers)) header headers
     in
     peek_char_fail
     >>= function

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -109,7 +109,7 @@ let headers =
   fix (fun headers ->
     let _emp = return (fun x -> x) in
     let _rec =
-      lift2 (fun header f headers -> f (header :: headers)) header headers
+      lift2 (fun header f headers -> f (header :: headers)) (header <* commit) headers
     in
     peek_char_fail
     >>= function

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -2,8 +2,8 @@
 
 let
   overlays = builtins.fetchTarball {
-    url = https://github.com/anmonteiro/nix-overlays/archive/efe73147.tar.gz;
-    sha256 = "0ny0dgm018i9x9xwr5356fkyqmy3jr325ypjsg35nx0jg597g7y6";
+    url = https://github.com/anmonteiro/nix-overlays/archive/fae33982.tar.gz;
+    sha256 = "0f1akg612xy8a1bjyk9s2bi8db5w77qbz7xgcpfijzxz20bfh816";
   };
 
 in


### PR DESCRIPTION
Upstream issue https://github.com/inhabitedtype/httpaf/issues/18 details
a case where the http/af parser is unable to parse a message if the read
buffer size isn't as big as all the bytes that form the message headers.
While it is desirable, and a design goal of the library, to be efficient
in parsing and thus avoid DoS attacks, it is more sensible to allow each
message header to fit within the read buffer size up to its limit. This
diff makes that change, which better accommodates real world use cases
for the default read buffer size.