### PR TITLE
Fix sending error responses, including chunked-encoded ones

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,8 @@ Unreleased
   ([#37](https://github.com/anmonteiro/httpaf/pull/37)).
 - httpaf-lwt: Close the communication channel after shutting down the client
   ([#45](https://github.com/anmonteiro/httpaf/pull/45))
+- httpaf: Fix sending streaming error responses; in particular, allow sending
+  chunk-encoded responses ([#56](https://github.com/anmonteiro/httpaf/pull/56))
 
 httpaf (upstream) 0.6.5
 --------------

--- a/lib/body.ml
+++ b/lib/body.ml
@@ -142,6 +142,9 @@ let has_pending_output t =
   Faraday.has_pending_output t.faraday
   || (Faraday.is_closed t.faraday && t.write_final_if_chunked)
 
+let requires_output t =
+  not (is_closed t) || has_pending_output t
+
 let close_reader t =
   Faraday.close t.faraday;
   execute_read t
@@ -150,7 +153,7 @@ let close_reader t =
 let when_ready_to_write t callback =
   if is_closed t
   then callback ()
-  else if Optional_thunk.is_some t.when_ready_to_write 
+  else if Optional_thunk.is_some t.when_ready_to_write
   then failwith "Body.when_ready_to_write: only one callback can be registered at a time"
   else t.when_ready_to_write <- Optional_thunk.some callback
 

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -282,8 +282,7 @@ let output_state t : Output_state.t =
   | Complete _ -> Complete
   | Waiting _ -> Wait
   | Streaming(_, response_body) ->
-    if not (Body.is_closed response_body)
-       || Body.has_pending_output response_body
+    if Body.requires_output response_body
     then Consume
     else Complete
   | Upgrade _ -> Consume

--- a/lib/respd.ml
+++ b/lib/respd.ml
@@ -127,9 +127,7 @@ let output_state { request_body; state; _ } : Output_state.t =
      * transition the response descriptor to the `Closed` state. *)
     Consume
   | state ->
-    if state = Uninitialized ||
-       not (Body.is_closed request_body) ||
-       Body.has_pending_output request_body
+    if state = Uninitialized || Body.requires_output request_body
     then Consume
     else Complete
 

--- a/lib/response_state.ml
+++ b/lib/response_state.ml
@@ -1,0 +1,56 @@
+module Output_state = struct
+  type t =
+    | Consume
+    | Wait
+    | Complete
+end
+
+type ('handle, 'io) t =
+  | Waiting   of Optional_thunk.t ref
+  | Complete  of Response.t
+  | Streaming of Response.t * [`write] Body.t
+  | Upgrade of Response.t * ('handle -> 'io)
+
+let upgrade_handler t =
+  match t with
+  | Upgrade (_, upgrade_handler) ->
+    Some upgrade_handler
+  | _ -> None
+
+let on_more_output_available t f =
+  match t with
+  | Waiting when_done_waiting ->
+    if Optional_thunk.is_some !when_done_waiting
+    then failwith "httpaf.Reqd.on_more_output_available: only one callback can be registered at a time";
+    when_done_waiting := Optional_thunk.some f
+  | Streaming(_, response_body) ->
+    Body.when_ready_to_write response_body f
+  | Complete _ ->
+    failwith "httpaf.Reqd.on_more_output_available: response already complete"
+  | Upgrade _ ->
+    (* XXX(anmonteiro): Connections that have been upgraded "require output"
+     * forever, but outside the HTTP layer, meaning they're permanently
+     * "yielding". We don't register the wakeup callback because it's not going
+     * to get called. *)
+    ()
+
+let output_state t : Output_state.t =
+  match t with
+  | Complete _ -> Complete
+  | Waiting _ -> Wait
+  | Streaming(_, response_body) ->
+    if Body.requires_output response_body
+    then Consume
+    else Complete
+  | Upgrade _ -> Consume
+
+let flush_response_body t ~request_method writer =
+  match t with
+  | Streaming (response, response_body) ->
+    let encoding =
+      match Response.body_length ~request_method response with
+      | `Fixed _ | `Close_delimited | `Chunked as encoding -> encoding
+      | `Error _ -> assert false (* XXX(seliopou): This needs to be handled properly *)
+    in
+    Body.transfer_to_writer_with_encoding response_body ~encoding writer
+  | _ -> ()

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -302,8 +302,18 @@ let flush_response_error_body t ?request response_state =
   let request_method = match request with
     | Some { Request.meth; _ } -> meth
     | None ->
-      (* XXX(anmonteiro): Error responses may not have a request method if
-       * they are the result of e.g. an EOF error. *)
+      (* XXX(anmonteiro): Error responses may not have a request method if they
+       * are the result of e.g. an EOF error. Assuming that the request method
+       * is `GET` smells a little because it's exposing implementation details,
+       * though the only case where it'd matter would be potentially assuming
+       * the _successful_ response to a CONNECT request and sending one of the
+       * forbidden headers according to RFC7231§4.3.6:
+       *
+       *   A server MUST NOT send any Transfer-Encoding or Content-Length
+       *   header fields in a 2xx (Successful) response to CONNECT.
+       *
+       * If we're running this code, however, we're not responding with a
+       * successful status code, which makes us compliant to the above. *)
       `GET
   in
   Response_state.flush_response_body response_state ~request_method t.writer

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -197,7 +197,8 @@ let set_error_and_handle ?request t error =
     match t.error_code with
     | No_error ->
       (* The (shared) response body buffer can be used in this case because in
-       * this branch we're sending a response, and therefore making use of that
+       * this conditional branch we're not sending a response
+       * (is_active t == false), and are therefore not making use of that
        * buffer. *)
       let response_body = Body.create t.response_body_buffer in
       t.error_code <- Error { request; response_state = Waiting (ref Optional_thunk.none) };

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -2,8 +2,8 @@
 
 let
   overlays = builtins.fetchTarball {
-    url = https://github.com/anmonteiro/nix-overlays/archive/fae33982.tar.gz;
-    sha256 = "0f1akg612xy8a1bjyk9s2bi8db5w77qbz7xgcpfijzxz20bfh816";
+    url = https://github.com/anmonteiro/nix-overlays/archive/e155620.tar.gz;
+    sha256 = "04jkwih5waknpqla928kjr5v6xp1q38p6yf04rcdgwj10cghr0ax";
   };
 
 in


### PR DESCRIPTION
TODOs:

- [x] Changelog
- [x] `set_error_and_handle` `Error` state re-entrancy (e.g. `SIGPIPE` when sending a streaming error response)