### PR TITLE
client: transfer the writer callback to the request body when yielding

### DIFF
--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -103,11 +103,10 @@ let yield_writer t k =
   | No_error ->
     if is_active t then
       let reqd = current_reqd_exn t in
-      begin match Reqd.output_state reqd with
+      match Reqd.output_state reqd with
       | Wait -> t.wakeup_writer <- Optional_thunk.some k
       | Consume -> Reqd.on_more_output_available reqd k
       | Complete -> k ()
-      end
     else
       t.wakeup_writer <- Optional_thunk.some k
   | Error { response_state; _ } ->


### PR DESCRIPTION
the writer on a request that has been sent

- applies the same fix as in #58 to the client connection
- adds additional tests that exercise the same behavior on the server