### PR TITLE
runtime read: Feed EOF to the state machine if the socket has been closed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,6 @@ jobs:
       with:
         name: anmonteiro
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - name: "Run nix-build"
       run: nix-build ./nix/ci/test.nix --argstr ocamlVersion ${{ matrix.ocamlVersion }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,10 @@ jobs:
         ocamlVersion: [4_07, 4_08, 4_09, 4_10]
     steps:
     - uses: actions/checkout@v2
-    - uses: cachix/install-nix-action@v7
-    - uses: cachix/cachix-action@v5
+    - uses: cachix/install-nix-action@v8
+    - uses: cachix/cachix-action@v6
       with:
         name: anmonteiro
-        file: ./nix/ci/test.nix
-        nixBuildArgs: --argstr ocamlVersion ${{ matrix.ocamlVersion }}
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+      run: nix-build ./nix/ci/test.nix --argstr ocamlVersion ${{ matrix.ocamlVersion }}
 

--- a/lwt-unix/httpaf_lwt_unix.ml
+++ b/lwt-unix/httpaf_lwt_unix.ml
@@ -57,8 +57,9 @@ module Io
           | 0 -> `Eof
           | n -> `Ok n)
       (function
-      | Unix.Unix_error (Unix.EBADF, _, _) as exn ->
-        Lwt.fail exn
+      | Unix.Unix_error (Unix.EBADF, _, _) ->
+        (* If the socket is closed we need to feed EOF to the state machine. *)
+        Lwt.return `Eof
       | exn ->
         Lwt.async (fun () -> close socket);
         Lwt.fail exn)

--- a/lwt-unix/ssl_io_real.ml
+++ b/lwt-unix/ssl_io_real.ml
@@ -68,8 +68,8 @@ struct
           | 0 -> `Eof
           | n -> `Ok n)
       (function
-        | Unix.Unix_error (Unix.EBADF, _, _) as exn ->
-          Lwt.fail exn
+        | Unix.Unix_error (Unix.EBADF, _, _) ->
+          Lwt.return `Eof
         | exn ->
           Lwt.async (fun () -> close ssl);
           Lwt.fail exn)

--- a/lwt-unix/tls_io_real.ml
+++ b/lwt-unix/tls_io_real.ml
@@ -53,8 +53,8 @@ module Io :
         | n ->
           `Ok n)
       (function
-        | Unix.Unix_error (Unix.EBADF, _, _) as exn ->
-          Lwt.fail exn
+        | Unix.Unix_error (Unix.EBADF, _, _) ->
+          Lwt.return `Eof
         | exn ->
           Lwt.async (fun () -> close tls);
           Lwt.fail exn)

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -2,8 +2,8 @@
 
 let
   overlays = builtins.fetchTarball {
-    url = https://github.com/anmonteiro/nix-overlays/archive/e155620.tar.gz;
-    sha256 = "04jkwih5waknpqla928kjr5v6xp1q38p6yf04rcdgwj10cghr0ax";
+    url = https://github.com/anmonteiro/nix-overlays/archive/ba9749d.tar.gz;
+    sha256 = "143fhjxgsbx3y0yi1kyrcw97b4fqvxg9sz5qzds323a7xvx85922";
   };
 
 in


### PR DESCRIPTION
This matters more in the client implementation, as we want the reader / writer threads to complete when a client issues a shutdown