### PR TITLE
Move yield / wakeup reader behavior to the Reader

### DIFF
--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -48,7 +48,6 @@ type t =
   ; request_queue : Respd.t Queue.t
     (* invariant: If [request_queue] is not empty, then the head of the queue
        has already written the request headers to the wire. *)
-  ; mutable wakeup_reader  : Optional_thunk.t
   }
 
 let is_closed t =
@@ -64,35 +63,11 @@ let current_respd_exn t =
   Queue.peek t.request_queue
 
 let yield_reader t k =
-  if is_closed t
-  then failwith "yield_reader on closed conn"
-  else if Optional_thunk.is_some t.wakeup_reader
-  then failwith "yield_reader: only one callback can be registered at a time"
-  else if is_active t then
-    let respd = current_respd_exn t in
-    begin match Respd.input_state respd with
-    | Wait ->
-      (* `Wait` means that the response body isn't closed yet (there may be
-       * more incoming bytes) but the response handler hasn't scheduled a read
-       * either. *)
-      Respd.on_more_input_available respd k
-    | Provide | Complete ->
-      (* `Complete` may happen when connection has been upgraded. *)
-      t.wakeup_reader <- Optional_thunk.some k
-    end
-  else t.wakeup_reader <- Optional_thunk.some k
+  if Reader.is_closed t.reader
+  then k ()
+  else Reader.on_wakeup t.reader k
 
-let wakeup_reader t =
-  let f = t.wakeup_reader in
-  t.wakeup_reader <- Optional_thunk.none;
-  Optional_thunk.call_if_some f
-
-let transfer_reader_callback t respd =
-  if Optional_thunk.is_some t.wakeup_reader
-  then (
-    let f = t.wakeup_reader in
-    t.wakeup_reader <- Optional_thunk.none;
-    Respd.on_more_input_available respd (Optional_thunk.unchecked_value f))
+let wakeup_reader t = Reader.wakeup t.reader
 
 let yield_writer t k =
  if Writer.is_closed t.writer
@@ -108,7 +83,6 @@ let[@ocaml.warning "-16"] create ?(config=Config.default) =
   ; reader = Reader.response request_queue
   ; writer = Writer.create ()
   ; request_queue
-  ; wakeup_reader = Optional_thunk.none
   }
 
 let request t request ~error_handler ~response_handler =
@@ -231,9 +205,7 @@ let rec _next_read_operation t =
   ) else (
     let respd = current_respd_exn t in
     match Respd.input_state respd with
-    | Wait ->
-      transfer_reader_callback t respd;
-      `Yield
+    | Wait -> `Yield
     | Provide  -> Reader.next t.reader
     | Complete -> _final_read_operation_for t respd
   )

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -257,7 +257,7 @@ module Reader = struct
     Optional_thunk.call_if_some f
 
   let request handler =
-    let parser t =
+    let parser t handler =
       request <* commit >>= fun request ->
         match Request.body_length request with
       | `Error `Bad_request -> return (Error (`Bad_request request))
@@ -272,11 +272,11 @@ module Reader = struct
         handler request request_body;
         body ~encoding request_body *> ok
     in
-    let rec t = lazy (create (parser t)) in
+    let rec t = lazy (create (parser t handler)) in
     Lazy.force t
 
   let response request_queue =
-    let parser t =
+    let parser t request_queue =
       response <* commit >>= fun response ->
       assert (not (Queue.is_empty request_queue));
       let exception Local of Respd.t in
@@ -304,7 +304,7 @@ module Reader = struct
         respd.response_handler response response_body;
         body ~encoding response_body *> ok
     in
-    let rec t = lazy (create (parser t)) in
+    let rec t = lazy (create (parser t request_queue)) in
     Lazy.force t
   ;;
 

--- a/lib/reqd.ml
+++ b/lib/reqd.ml
@@ -228,9 +228,6 @@ let error_code t =
   | #error as error -> Some error
   | `Ok             -> None
 
-let on_more_input_available t f =
-  Body.when_ready_to_read t.request_body f
-
 let persistent_connection t =
   t.persistent
 

--- a/lib/respd.ml
+++ b/lib/respd.ml
@@ -58,19 +58,6 @@ let write_request t =
   Writer.write_request t.writer t.request;
   t.state <- Awaiting_response
 
-let on_more_input_available t f =
-  match t.state with
-  | Received_response (_, response_body) ->
-    Body.when_ready_to_read response_body f
-
-  (* Don't expect to be called in these states. *)
-  | Uninitialized
-  | Awaiting_response ->
-    failwith "httpaf.Respd.on_more_input_available: response hasn't started"
-  | Upgraded _
-  | Closed ->
-    failwith "httpaf.Respd.on_more_input_available: response already complete"
-
 let report_error t error =
   t.persistent <- false;
   match t.state, t.error_code with

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -60,11 +60,10 @@ type t =
   ; request_queue          : Reqd.t Queue.t
     (* invariant: If [request_queue] is not empty, then the head of the queue
        has already had [request_handler] called on it. *)
-  ; mutable wakeup_reader  : Optional_thunk.t
+  ; mutable error_code : error_code
     (* Represents an unrecoverable error that will cause the connection to
      * shutdown. Holds on to the response body created by the error handler
      * that might be streaming to the client. *)
-  ; mutable error_code : error_code
   }
 
 let is_closed t =
@@ -80,43 +79,17 @@ let current_reqd_exn t =
   Queue.peek t.request_queue
 
 let yield_reader t k =
-  if is_closed t
-  then failwith "yield_reader on closed conn"
-  else if Optional_thunk.is_some t.wakeup_reader
-  then failwith "yield_reader: only one callback can be registered at a time"
-  else if is_active t then
-    let reqd = current_reqd_exn t in
-    begin match Reqd.input_state reqd with
-    | Wait ->
-      (* `Wait` means that the request body isn't closed yet (there may be more
-       * incoming bytes) but the request handler hasn't scheduled a read
-       * either. *)
-      Reqd.on_more_input_available reqd k
-    | Provide | Complete -> t.wakeup_reader <- Optional_thunk.some k
-    end
-  else
-    t.wakeup_reader <- Optional_thunk.some k
-;;
+  if Reader.is_closed t.reader
+  then k ()
+  else Reader.on_wakeup t.reader k
 
-let wakeup_reader t =
-  let f = t.wakeup_reader in
-  t.wakeup_reader <- Optional_thunk.none;
-  Optional_thunk.call_if_some f
-;;
-
-let transfer_reader_callback t reqd =
-  if Optional_thunk.is_some t.wakeup_reader
-  then (
-    let f = t.wakeup_reader in
-    t.wakeup_reader <- Optional_thunk.none;
-    Reqd.on_more_input_available reqd (Optional_thunk.unchecked_value f))
-;;
+let wakeup_reader t = Reader.wakeup t.reader
 
 let yield_writer t k =
  if Writer.is_closed t.writer
  (* TODO: this should probably be an error. Why would the runtime call `yield`
   * if we told it to close? *)
- then k ()
+ then assert false
  else Writer.on_wakeup t.writer k
 ;;
 
@@ -155,7 +128,6 @@ let create ?(config=Config.default) ?(error_handler=default_error_handler) reque
   ; request_handler = request_handler
   ; error_handler   = error_handler
   ; request_queue
-  ; wakeup_reader   = Optional_thunk.none
   ; error_code = No_error
   }
 
@@ -261,9 +233,7 @@ let rec _next_read_operation t =
        * close. *)
       begin match Reader.next t.reader with
       | `Error _ as operation -> operation
-      | _ ->
-       transfer_reader_callback t reqd;
-       `Yield
+      | _ -> `Yield
       end
     | Provide  -> Reader.next t.reader
     | Complete -> _final_read_operation_for t reqd

--- a/lib_test/test_httpaf.ml
+++ b/lib_test/test_httpaf.ml
@@ -1273,8 +1273,8 @@ Accept-Language: en-US,en;q=0.5\r\n\r\n";
     reader_yielded t;
     yield_reader t (fun () -> reader_woken_up := true);
     !continue_reading ();
-    reader_ready ~msg:"Reader wants to read if there's a read scheduled in the body" t;
     Alcotest.(check bool) "Reader wakes up if scheduling read" true !reader_woken_up;
+    reader_ready ~msg:"Reader wants to read if there's a read scheduled in the body" t;
     writer_yielded t;
   ;;
 
@@ -1296,8 +1296,8 @@ Accept-Language: en-US,en;q=0.5\r\n\r\n";
     read_string t "five.";
     reader_yielded t;
     !continue_reading ();
-    reader_ready ~msg:"Reader wants to read if there's a read scheduled in the body" t;
     Alcotest.(check bool) "Reader wakes up if scheduling read" true !reader_woken_up;
+    reader_ready ~msg:"Reader wants to read if there's a read scheduled in the body" t;
     writer_yielded t;
   ;;
 


### PR DESCRIPTION
This is the same change that was done in
https://github.com/anmonteiro/httpaf/pull/67, but for the reader.
Besides allowing us to delete a bunch of common, duplicated code, this
change has the additional benefit of unifying the callback logic for the
Body module.