### PR TITLE
Head response content length fix

### DIFF
--- a/lib/response.ml
+++ b/lib/response.ml
@@ -52,11 +52,18 @@ let create ?reason ?(version=Version.v1_1) ?(headers=Headers.empty) status =
 let persistent_connection ?proxy { version; headers; _ } =
   Message.persistent_connection ?proxy version headers
 
+let is_head meth =
+  begin match meth with
+  | `HEAD -> true
+  | _ -> false
+  end
+
 let proxy_error  = `Error `Bad_gateway
 let server_error = `Error `Internal_server_error
 let body_length ?(proxy=false) ~request_method { status; headers; _ } =
   match status, request_method with
   | (`No_content | `Not_modified), _           -> `Fixed 0L
+  | _, `HEAD                                   -> `Fixed 0L
   | s, _        when Status.is_informational s -> `Fixed 0L
   | s, `CONNECT when Status.is_successful s    -> `Close_delimited
   | _, _                                       ->

--- a/lib_test/test_client_connection.ml
+++ b/lib_test/test_client_connection.ml
@@ -207,6 +207,30 @@ let test_get () =
   read_string t "d\r\nHello, world!\r\n0\r\n\r\n";
 ;;
 
+let test_head () =
+  let request' = Request.create `HEAD "/" in
+  let response = Response.create
+      ~headers:(Headers.of_list ["content-length", "100500"])
+      `OK
+  in
+
+  (* Single GET *)
+  let t = create ?config:None in
+  let body =
+    request
+      t
+      request'
+      ~response_handler:(default_response_handler response)
+      ~error_handler:no_error_handler
+  in
+  Body.close_writer body;
+  write_request t request';
+  read_response t response;
+  let c = read_eof t Bigstringaf.empty ~off:0 ~len:0 in
+  Alcotest.(check int) "read_eof with no input returns 0" 0 c;
+  connection_is_shutdown t;
+;;
+
 let test_get_last_close () =
   (* Multiple GET requests, the last one closes the connection *)
   let request' = Request.create `GET "/" in
@@ -1355,6 +1379,7 @@ let test_chunked_error () =
 let tests =
   [ "commit parse after every header line", `Quick, test_commit_parse_after_every_header
   ; "GET"         , `Quick, test_get
+  ; "HEAD"        , `Quick, test_head
   ; "Response EOF", `Quick, test_response_eof
   ; "Response header order preserved", `Quick, test_response_header_order
   ; "report_exn"  , `Quick, test_report_exn


### PR DESCRIPTION
According to RFCs, HEAD requests do not have any content, but may include
content length to inform the client about the size of the resource.