### PR TITLE
Perform one less copy when parsing the message body

### DIFF
--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -155,7 +155,7 @@ let schedule_size body n =
    * intemediate copy, this should be back to the original performance. *)
   begin if Faraday.is_closed faraday
   then advance n
-  else take n >>| fun s -> Faraday.write_string faraday s
+  else take_bigstring n >>| fun s -> Faraday.schedule_bigstring faraday s
   end *> commit
 
 let body ~encoding body =


### PR DESCRIPTION
`take_bigstring` still makes a copy. Need to check whether we can avoid that one too.