### PR TITLE
Fix EOF invariant for empty bodies

### DIFF
--- a/lib/body.ml
+++ b/lib/body.ml
@@ -58,8 +58,6 @@ module Reader = struct
     Faraday.close t.faraday;
     t
 
-  let empty = create_empty ()
-
   let is_closed t =
     Faraday.is_closed t.faraday
 

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -260,7 +260,7 @@ module Reader = struct
         match Request.body_length request with
       | `Error `Bad_request -> return (Error (`Bad_request request))
       | `Fixed 0L  ->
-        handler request Body.Reader.empty;
+        handler request (Body.Reader.create_empty ());
         ok
       | `Fixed _ | `Chunked as encoding ->
         let request_body =
@@ -292,7 +292,7 @@ module Reader = struct
       | `Error `Bad_gateway           -> assert (not proxy); assert false
       | `Error `Internal_server_error -> return (Error (`Invalid_response_body_length response))
       | `Fixed 0L ->
-        respd.response_handler response Body.Reader.empty;
+        respd.response_handler response (Body.Reader.create_empty ());
         ok
       | `Fixed _ | `Chunked | `Close_delimited as encoding ->
         (* We do not trust the length provided in the [`Fixed] case, as the

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -2,7 +2,7 @@
 
 let
   overlays = builtins.fetchTarball
-    https://github.com/anmonteiro/nix-overlays/archive/4e497d8.tar.gz;
+    https://github.com/anmonteiro/nix-overlays/archive/152f359.tar.gz;
 
 in
 


### PR DESCRIPTION
after #101 the `eof_has_been_called` field tracks if the EOF callback
has been called when reading a message body. This mutable field requires
that empty bodies be created everytime rather than reusing the same one
every time, or `on_eof` callbacks will never be called at all after the
first one.