### PR TITLE
fix: call request handlers for multiple pipelined requests

### DIFF
--- a/lib/body.ml
+++ b/lib/body.ml
@@ -38,7 +38,7 @@ module Reader = struct
     ; mutable on_eof                 : unit -> unit
     ; mutable eof_has_been_called    : bool
     ; mutable on_read                : Bigstringaf.t -> off:int -> len:int -> unit
-    ; mutable when_ready_to_read     : Optional_thunk.t
+    ; when_ready_to_read             : Optional_thunk.t
     }
 
   let default_on_eof         = Sys.opaque_identity (fun () -> ())

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -227,7 +227,7 @@ and _final_read_operation_for t respd =
       | Waiting | Ready -> `Yield
       | Complete       ->
          match Reader.next t.reader with
-         | `Error _ | `Read as operation->
+         | `Error _ | `Read as operation ->
            (* Keep reading when in a "partial" state (`Read).
             * Don't advance the request queue if in an error state. *)
            operation

--- a/lib/client_connection.ml
+++ b/lib/client_connection.ml
@@ -176,7 +176,8 @@ let maybe_pipeline_queued_requests t =
         | Some prev ->
           match respd.Respd.state, Respd.output_state prev with
           | Uninitialized, Complete ->
-            Respd.write_request respd
+            Respd.write_request respd;
+            Respd.flush_request_body respd
           | _ ->
             (* bail early. If we can't pipeline this request, we can't write
              * next ones either. *)
@@ -300,7 +301,7 @@ and _final_write_operation_for t respd =
       Writer.next t.writer;
     | Complete ->
        match Reader.next t.reader with
-       | `Error _ | `Read  -> Writer.next t.writer
+       | `Error _ -> Writer.next t.writer
        | _ ->
          advance_request_queue t;
          wakeup_reader t;

--- a/lib/parse.ml
+++ b/lib/parse.ml
@@ -284,7 +284,7 @@ module Reader = struct
             raise (Local respd)) request_queue)
         with
         | exception Local respd -> respd
-        | _ -> assert false
+        | () -> assert false
       in
       let request = Respd.request respd in
       let proxy = false in

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -121,7 +121,11 @@ let create ?(config=Config.default) ?(error_handler=default_error_handler) reque
     let reqd =
       Reqd.create error_handler request request_body (Lazy.force reader) writer response_body_buffer
     in
+    let call_handler = Queue.is_empty request_queue in
     Queue.push reqd request_queue;
+    if call_handler
+    then request_handler reqd;
+
   and t = lazy
     { reader = Lazy.force reader
     ; writer
@@ -313,8 +317,6 @@ let read_with_more t bs ~off ~len more =
   if is_active t
   then (
     let reqd = current_reqd_exn t in
-    if call_handler
-    then t.request_handler reqd;
     Reqd.flush_request_body reqd;
   );
   consumed

--- a/lib/server_connection.ml
+++ b/lib/server_connection.ml
@@ -312,7 +312,6 @@ let next_read_operation t =
   | (`Yield | `Close) as operation -> operation
 
 let read_with_more t bs ~off ~len more =
-  let call_handler = Queue.is_empty t.request_queue in
   let consumed = Reader.read_with_more t.reader bs ~off ~len more in
   if is_active t
   then (

--- a/lib_test/test_server_connection.ml
+++ b/lib_test/test_server_connection.ml
@@ -1787,7 +1787,8 @@ let test_multiple_requests_in_single_read () =
   in
   read_string t reqs;
 
-  write_string t (response_to_string response ^ response_to_string response);
+  write_string t (response_to_string response );
+  write_string t (response_to_string response );
 ;;
 
 let test_multiple_async_requests_in_single_read () =
@@ -1895,7 +1896,8 @@ let test_multiple_requests_in_single_read_with_eof () =
     request_to_string (Request.create `GET "/")
   in
   read_string t reqs ~eof:true;
-  write_string t (response_to_string response ^ response_to_string response);
+  write_string t (response_to_string response);
+  write_string t (response_to_string response);
 ;;
 
 let test_parse_failure_after_checkpoint () =


### PR DESCRIPTION
happens when the read buffer might share multiple pipelined requests