### PR TITLE
Body.Writer: call `flush` callback only after bytes have been written to the transport

### DIFF
--- a/lib/body.ml
+++ b/lib/body.ml
@@ -165,7 +165,8 @@ module Writer = struct
   let ready_to_write t = Serialize.Writer.wakeup t.writer
 
   let flush t kontinue =
-    Faraday.flush t.faraday kontinue;
+    Faraday.flush t.faraday (fun () ->
+      Serialize.Writer.flush t.writer kontinue);
     ready_to_write t
 
   let is_closed t =


### PR DESCRIPTION
- The `Body.Writer.t` type does its own buffering
- It's not enough to wait for it to flush to the writer, it should also wait for the writer to flush to the underlying transport
- this enables waiting for e.g. response headers to be fully written to the wire before upgrading a connection or e.g. calling the `sendfile` syscall.