### PR TITLE
Headers.get_exn: raise `Not_found` instead of Failure

### DIFF
--- a/lib/headers.ml
+++ b/lib/headers.ml
@@ -138,7 +138,7 @@ let get t name =
 let get_exn t name =
   let rec loop t n =
     match t with
-    | [] -> Not_found
+    | [] -> raise Not_found
     | (n',v)::t' -> if CI.equal n n' then v else loop t' n
   in
   loop t name

--- a/lib/headers.ml
+++ b/lib/headers.ml
@@ -138,7 +138,7 @@ let get t name =
 let get_exn t name =
   let rec loop t n =
     match t with
-    | [] -> failwith (Printf.sprintf "Headers.get_exn: %S not found" name)
+    | [] -> Not_found
     | (n',v)::t' -> if CI.equal n n' then v else loop t' n
   in
   loop t name

--- a/lib/httpaf.mli
+++ b/lib/httpaf.mli
@@ -431,7 +431,7 @@ module Headers : sig
 
   val get_exn : t -> name -> value
   (** [get t name] returns the last header from [t] with name [name], or raises
-      if no such header is present. *)
+      [Not_found] if no such header is present. *)
 
   val get_multi : t -> name -> value list
   (** [get_multi t name] is the list of header values in [t] whose names are


### PR DESCRIPTION
- `Failure` shouldn't be raised by libraries
- `get_exn` should raise `Not_found`
- we should probably raise `Invalid_argument` in some other places we're raising right now.